### PR TITLE
0.1.3 - Route Loading Event and Deprecate Singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,8 @@ import '@capitec/omni-router';
 5️⃣ &nbsp; Define the pages you will route to.
 
 ```js
- // Iniitialize the router.
-const router = Router.getInstance();
-
 // Register the app routes.
-router.addRoute({
+Router.addRoute({
     name: 'view-fade',
     title: 'Fade',
     path: '/fade',
@@ -96,7 +93,7 @@ router.addRoute({
 });
 
 // Load the route matching the current browser path.
-router.load();
+Router.load();
 ```
 
 <br>
@@ -119,11 +116,8 @@ This example sets up a simple web page containing the Omni Router. Routes are re
         <script type="module">
             import { Router } from '@capitec/omni-router';
 
-            // Iniitialize the router.
-            const router = Router.getInstance();
-
             // Register the app routes.
-            router.addRoute({
+            Router.addRoute({
                 name: 'view-fade',
                 title: 'Fade',
                 path: '/fade',
@@ -132,7 +126,7 @@ This example sets up a simple web page containing the Omni Router. Routes are re
                 isDefault: true
             });
 
-            router.addRoute({
+            Router.addRoute({
                 name: 'view-slide',
                 title: 'Slide',
                 path: '/slide',
@@ -140,7 +134,7 @@ This example sets up a simple web page containing the Omni Router. Routes are re
                 load: () => import('./views/ViewSlide')
             });
 
-            router.addRoute({
+            Router.addRoute({
                 name: 'view-pop',
                 title: 'Pop',
                 path: '/pop',
@@ -148,7 +142,7 @@ This example sets up a simple web page containing the Omni Router. Routes are re
                 load: () => import('./views/ViewPop')
             });
 
-            router.addRoute({
+            Router.addRoute({
                 name: 'view-guarded',
                 title: 'Guarded Route',
                 path: '/guarded',
@@ -156,7 +150,7 @@ This example sets up a simple web page containing the Omni Router. Routes are re
                 guard: () => !this._isUserLoggedIn()
             });
 
-            router.addRoute({
+            Router.addRoute({
                 name: 'view-fallback',
                 title: 'Fallback Route',
                 path: '/error404',
@@ -165,7 +159,7 @@ This example sets up a simple web page containing the Omni Router. Routes are re
             });
 
             // Load the route matching the current browser path.
-            router.load();
+            Router.load();
         </script>
 
         <script type="module" src="./AppShell.js"></script>
@@ -188,9 +182,6 @@ class ViewFade extends HTMLElement {
 
         super();
 
-        // Connect application services.
-        this._router = Router.getInstance();
-
         // Create the DOM content template.
         const template = document.createElement('template');
         template.innerHTML = `
@@ -212,7 +203,7 @@ class ViewFade extends HTMLElement {
         this.shadowRoot.appendChild(template.content.cloneNode(true));
 
         // Register element event listeners.
-        this.shadowRoot.querySelector('#back').addEventListener('click', () => this._router.pop());
+        this.shadowRoot.querySelector('#back').addEventListener('click', () => Router.pop());
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ The ```Router``` class provides the following properties and functions:
 | ```getRouteForPath(pathOrUrl: string): Route \| null``` | Get the registered route for the given path. |
 | ```setDefault(name: string): boolean``` | Set the route that should be rendered when navigating to the app base URL. |
 | ```setFallback(name: string): boolean``` | Set the route that should be rendered when navigating to a route that does not exist. |
-| ```load(): Promise\<void\>``` | Navigate to the current browser URL path. |
+| ```load(): Promise<void>``` | Navigate to the current browser URL path. |
 | ```push(path: string, state = {}): Promise\<void\>``` | Push a new path onto the browser history stack and render it's registered route. |
 | ```replace(path: string, state = {}): Promise\<void\>``` | Update the current path in the browser history stack with a new path and render it's registered route. |
 | ```pop(): void``` | Pops the current path in the browser history stack and navigate the previous path. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.0.11",
+	"version": "0.1.1",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -4,6 +4,7 @@ import { Route, RouteAnimationIn, RouteAnimationOut, RouterEventCallback, Router
  * Map of subscribers that listen to router events.
  */
 type RouteEventListenersMap = {
+	'route-loading': RouterEventCallback[];
 	'route-loaded': RouterEventCallback[];
 };
 
@@ -70,6 +71,7 @@ export class Router {
 
 	/** Map of the events dispatch by the router and their listeners. */
 	private _eventListeners: RouteEventListenersMap = {
+		'route-loading': [],
 		'route-loaded': []
 	};
 
@@ -598,6 +600,15 @@ export class Router {
 
 		// Request that the router outlet render the new route.
 		if (this.onNavigate) {
+
+			// Notify subscribers that the route has started loading.
+			for (const listener of this._eventListeners['route-loading']) {
+
+				listener({
+					previous: this._previousLocation,
+					current: this._currentLocation
+				});
+			}
 
 			// Load the route.
 			await this.onNavigate(this._currentLocation, animation);

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -61,10 +61,7 @@ export type RouteNavigationFunction = (route: RoutedLocation, animation?: RouteA
  *   <omni-router-outlet></omni-router-outlet>
  * ```
  */
-export class Router {
-
-	/**  The singleton instance of the router. */
-	private static _instance: Router;
+class RouterImpl {
 
 	/** The registered route configurations. */
 	private _routes: Route[] = [];
@@ -91,7 +88,7 @@ export class Router {
 	/**
 	 * Initialize the router.
 	 */
-	private constructor() {
+	constructor() {
 
 		// Update the visible route when browser navigation buttons are pressed or the History API is used directly to navigate.
 		window.addEventListener('popstate', async () => { // eslint-disable-line @typescript-eslint/no-misused-promises
@@ -102,11 +99,13 @@ export class Router {
 	/**
 	 * Get the singleton instance of the router.
 	 * 
+	 * @deprecated Use Router module directly instead, e.g. Router.addRoute(...) instead of Router.getInstance.addRoute()
+	 * 
 	 * @returns The router instance.
 	 */
-	static getInstance(): Router {
+	getInstance(): this {
 
-		return this._instance || (this._instance = new Router());
+		return this;
 	}
 
 	// ----------
@@ -658,3 +657,6 @@ export class Router {
 		return pathParams;
 	}
 }
+
+// Export a singleton instance of the router.
+export const Router = new RouterImpl();

--- a/src/RouterOutlet.ts
+++ b/src/RouterOutlet.ts
@@ -32,9 +32,6 @@ type RouteTask = {
  */
 export class RouterOutlet extends HTMLElement {
 
-	/** The instance to the router singleton. */
-	private _router: Router;
-
 	/** The routed location that is currently loaded in the outlet. */
 	private _currentLocation?: RoutedLocation;
 
@@ -59,7 +56,6 @@ export class RouterOutlet extends HTMLElement {
 		super();
 
 		// Initialize default properties.
-		this._router = Router.getInstance();
 		this._isAnimating = false;
 
 		// Create the element shadow root.
@@ -227,7 +223,7 @@ export class RouterOutlet extends HTMLElement {
 	connectedCallback(): void {
 
 		// Set this outlet as the route rendering handler for the router.
-		this._router.onNavigate = (route, animation): Promise<void> => this._loadRoute(route, animation);
+		Router.onNavigate = (route, animation): Promise<void> => this._loadRoute(route, animation);
 	}
 
 	/**
@@ -236,7 +232,7 @@ export class RouterOutlet extends HTMLElement {
 	disconnectedCallback(): void {
 
 		// Stop rendering on router navigation changes.
-		this._router.onNavigate = undefined;
+		Router.onNavigate = undefined;
 	}
 
 	// ----------

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type RouteAnimation = 'fade' | 'slide' | 'pop';
 /**
  * List of events dispatched by the router.
  */
-export type RouterEventType = 'route-loaded';
+export type RouterEventType = 'route-loading' | 'route-loaded';
 
 /**
  * The callback function invoked when a route is loaded.


### PR DESCRIPTION
### Description:

This merge request merges the latest features from develop in to main for the 0.1.3 release, including:
- Deprecating the Router.getInstance() function
- Adding a new routeLoading event that fires just prior to the route navigation

### Screenshots (if appropriate):

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
