### PR TITLE
Update Router.ts to be more compliant with history api for replace state

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -488,7 +488,7 @@ class RouterImpl {
 		history.replaceState(state, route.name, path);
 
 		// Render the route that matches the browser URL path.
-		await this._applyRoute(route);
+		await this._applyRoute(route, false, true);
 	}
 
 	/**
@@ -566,16 +566,19 @@ class RouterImpl {
 	 * 
 	 * @param route - The route to navigate to.
 	 * @param animateOut - Set to animate out the current view using the opposite effect of how it was animated in.
+	 * @param isReplace - Set to prevent updating previousLocation for replaces as per the native history api.
 	 */
-	private async _applyRoute(route: Route, animateOut = false): Promise<void> {
+	private async _applyRoute(route: Route, animateOut = false, isReplace = false): Promise<void> {
 
 		// Set the page title.
 		if (route.title) {
 			document.title = route.title;
 		}
 
-		// Keep record of the route history.
-		this._previousLocation = this._currentLocation;
+	        if (!isReplace) {
+	            // Keep record of the route history.
+	            this._previousLocation = this._currentLocation;
+	        }
 
 		// Build up the new route information.
 		this._currentLocation = {


### PR DESCRIPTION
### Description:

Currently on replace of router state, the `previousLocation` also gets updated. This is not the same as when calling replace on the history api and affects the ability to go back.

### All Submissions:

* [X] I have followed the guidelines in the Contributing document.
* [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [X] I have added an explanation of what my changes do and why I would like to include them.
* [X] I have written new tests for my core changes, as applicable.
* [X] I have successfully ran tests with my changes locally.
* [X] I have added/updated docs, as applicable.
