### PR TITLE
Omni Router 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,11 @@ The ```Router``` class provides the following properties and functions:
 | ```getRouteForPath(pathOrUrl: string): Route \| null``` | Get the registered route for the given path. |
 | ```setDefault(name: string): boolean``` | Set the route that should be rendered when navigating to the app base URL. |
 | ```setFallback(name: string): boolean``` | Set the route that should be rendered when navigating to a route that does not exist. |
-| ```load(): Promise<\boolean\>``` | Navigate to the current browser URL path. |
-| ```push(path: string, state = {}, animateOut = false): Promise<\boolean\>``` | Push a new path onto the browser history stack and render it's registered route. |
-| ```replace(path: string, state = {}, animateOut = false): Promise<\boolean\>``` | Update the current path in the browser history stack with a new path and render it's registered route. |
-| ```pop(delta?: number): Promise<\boolean\>``` | Pops the current path in the browser history stack and navigate the previous path, or specified number pages back. |
-| ```popToPath(path: string, before = false): Promise<\boolean\>``` | Pops back in history to a previous path, removing all paths after this point from the stack. |
+| ```load(): Promise<boolean>``` | Navigate to the current browser URL path. |
+| ```push(path: string, state = {}, animateOut = false): Promise<boolean>``` | Push a new path onto the browser history stack and render it's registered route. |
+| ```replace(path: string, state = {}, animateOut = false): Promise<boolean>``` | Update the current path in the browser history stack with a new path and render it's registered route. |
+| ```pop(delta?: number): Promise<boolean>``` | Pops the current path in the browser history stack and navigate the previous path, or specified number pages back. |
+| ```popToPath(path: string, before = false): Promise<boolean>``` | Pops back in history to a previous path, removing all paths after this point from the stack. |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ The ```Route``` object contains the following properties:
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| **name** | string | The registered custom-element tag name for your page web component, e.g. ```'view-login'``` |
+| **name** | string | The unique identifier for the route, must be the tag name of the web component if tag is not set. |
+| **tag** | string | Optional, the registered custom-element tag name for your page web component, e.g. ```'view-login'``` |
 | **title** | string | The window title to show when the route is loaded, e.g. ```'Login'``` |
 | **animation** | string | Optional, animation to apply when loading the route. Can be one of ```fade```, ```slide```, ```pop```
 | **load** | function | Optional, function to execute before navigating to the route. Typically used to lazy load the page web component, e.g. <br>```() => import('./views/ViewLogin')``` |
@@ -338,10 +339,11 @@ The ```Router``` class provides the following properties and functions:
 | ```getRouteForPath(pathOrUrl: string): Route \| null``` | Get the registered route for the given path. |
 | ```setDefault(name: string): boolean``` | Set the route that should be rendered when navigating to the app base URL. |
 | ```setFallback(name: string): boolean``` | Set the route that should be rendered when navigating to a route that does not exist. |
-| ```load(): Promise<void>``` | Navigate to the current browser URL path. |
-| ```push(path: string, state = {}): Promise\<void\>``` | Push a new path onto the browser history stack and render it's registered route. |
-| ```replace(path: string, state = {}): Promise\<void\>``` | Update the current path in the browser history stack with a new path and render it's registered route. |
-| ```pop(): void``` | Pops the current path in the browser history stack and navigate the previous path. |
+| ```load(): Promise<\boolean\>``` | Navigate to the current browser URL path. |
+| ```push(path: string, state = {}, animateOut = false): Promise<\boolean\>``` | Push a new path onto the browser history stack and render it's registered route. |
+| ```replace(path: string, state = {}, animateOut = false): Promise<\boolean\>``` | Update the current path in the browser history stack with a new path and render it's registered route. |
+| ```pop(delta?: number): Promise<\boolean\>``` | Pops the current path in the browser history stack and navigate the previous path, or specified number pages back. |
+| ```popToPath(path: string, before = false): Promise<\boolean\>``` | Pops back in history to a previous path, removing all paths after this point from the stack. |
 
 <br>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@capitec/omni-router",
-			"version": "0.1.5",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -841,13 +841,7 @@ class RouterImpl {
 	 */
 	private _getPathString(source: string): string {
 
-		const result = source.replace(window.location.origin, '');
-
-		if (!result || result === '') {
-			return '/';
-		}
-
-		return result;
+		return source.replace(window.location.origin, '');
 	}
 }
 

--- a/src/RouterOutlet.ts
+++ b/src/RouterOutlet.ts
@@ -342,7 +342,7 @@ export class RouterOutlet extends HTMLElement {
 
 		// Add the page component to the router display.
 		const oldRouteComponent = this._getCurrentRouteComponent();
-		const newRouteComponent = document.createElement(route.name);
+		const newRouteComponent = document.createElement(route.tag ?? route.name);
 
 		newRouteComponent.classList.add('page');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,8 +36,11 @@ export type RouterEventCallback = (detail: { previous?: RoutedLocation, current:
  */
 export type Route = {
 
-	/** The tag name of the web component to render for this route. */
+	/** The unique identifier for the route, must be the tag name of the web component if tag is not set. */
 	name: string;
+
+	/** The tag name of the web component to render for this route. */
+	tag?: string;
 
 	/** The relative URL path for the route to set in the browser navigation bar. */
 	path: string;


### PR DESCRIPTION
1. Allow the same tag name to be registered for different paths, by providing an additional 'tag' property in the route definition.
2. Make the pop() function return a promise that resolves once the routing event is received.
3. Add a delta argument to the pop() function to allow for jumping back multiple pages.
4. Add a new popToPath() function that will attempt to jump back the required number of pages to return to  a given previous path.
5. Make the return type of all routing function return a boolean that indicates if the routing event was allowed to proceed.
6. Add an animateOut argument the the push() and replace() function to invert the animation behavior when routing to a path

### Screenshots (if appropriate):

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
