### PR TITLE
Extend path part regex check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@capitec/omni-router",
-			"version": "0.2.1",
+			"version": "0.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -331,9 +331,9 @@ class RouterImpl {
 			for (let i = 0; i < routeParts.length; i++) {
 
 				if (routeParts[i].endsWith('?')) {
-					routeParts[i] = '?[-.a-zA-Z0-9]*';
+					routeParts[i] = '?[-.a-zA-Z0-9 %]*';
 				} else if (routeParts[i].startsWith(':')) {
-					routeParts[i] = '[-.a-zA-Z0-9]+';
+					routeParts[i] = '[-.a-zA-Z0-9 %]+';
 				}
 			}
 


### PR DESCRIPTION
### Description:

Extend regex for path matching to include string literal space as well as `%` character for encoded path or query values.

### Screenshots (if appropriate):

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [ ] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [ ] I have added/updated docs, as applicable.
