### PR TITLE
Fix memory leak caused by not removing animationend event listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-router",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "Framework agnostic, zero dependency, client-side web component router",
 	"author": "Capitec",
 	"license": "MIT",

--- a/src/RouterOutlet.ts
+++ b/src/RouterOutlet.ts
@@ -356,6 +356,7 @@ export class RouterOutlet extends HTMLElement {
 
 				// Clean up the animation once done.
 				newRouteComponent.addEventListener('animationend', () => {
+
 					// Clear the animation from the element.
 					newRouteComponent.classList.remove(animation, 'animate');
 
@@ -366,7 +367,8 @@ export class RouterOutlet extends HTMLElement {
 
 					// Mark the routing task as complete.
 					resolve();
-				});
+
+				}, { once: true });
 
 				// Add the new route component to the top of the view stack so the the animation is visible.
 				this.shadowRoot?.append(newRouteComponent);
@@ -385,6 +387,7 @@ export class RouterOutlet extends HTMLElement {
 
 					// Clean up the animation once done.
 					oldRouteComponent.addEventListener('animationend', () => {
+
 						// Clear the animation from the element.
 						oldRouteComponent.classList.remove(animation, 'animate');
 
@@ -393,7 +396,8 @@ export class RouterOutlet extends HTMLElement {
 
 						// Mark the routing task as complete.
 						resolve();
-					});
+
+					}, { once: true });
 
 					// Add the new route component to the bottom of the view stack so the the animation is visible.
 					this.shadowRoot?.prepend(newRouteComponent);


### PR DESCRIPTION
### Description:

The animationend event in the router outlet is registered using addEventLister, but never removed. This causes a memory leak where the page being animated out is never / poorly garbage collected as pointer to the page is not removed. This change registers the event listener to run only once and then remove itself.

### Screenshots (if appropriate):

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
